### PR TITLE
refactor: declare Renderable interface

### DIFF
--- a/pypst/document.py
+++ b/pypst/document.py
@@ -1,19 +1,27 @@
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Optional
+
+from pypst import utils
+from pypst.renderable import Renderable
 
 
 @dataclass
 class Document:
-    body: Any
-
+    body: Renderable | str
     imports: list["Import"] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.body, (Renderable, str)):
+            raise ValueError(f"Invalid body type: {type(self.body)}")
+        elif isinstance(self.body, Document):
+            raise ValueError("Document cannot be set as body of another document")
 
     def add_import(self, module: str, members: Optional[list[str]] = None) -> None:
         self.imports.append(Import(module, members or []))
 
     def render(self) -> str:
         imports = "\n".join([i.render() for i in self.imports])
-        body: str = self.body.render()
+        body: str = utils.render(self.body)
 
         if imports:
             return f"{imports}\n\n{body}"

--- a/pypst/figure.py
+++ b/pypst/figure.py
@@ -1,10 +1,14 @@
 from dataclasses import dataclass
-from typing import Optional, Any
+from typing import Optional
+
+from pypst import utils
+from pypst.document import Document
+from pypst.renderable import Renderable
 
 
 @dataclass
 class Figure:
-    body: Any
+    body: Renderable | str
 
     placement: Optional[str] = None
     caption: Optional[str] = None
@@ -14,9 +18,17 @@ class Figure:
     gap: Optional[str] = None
     outlined: Optional[bool] = None
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.body, (Renderable, str)):
+            raise ValueError(f"Invalid body type: {type(self.body)}")
+        elif isinstance(self.body, Document):
+            raise ValueError(
+                "Document cannot be set as body, because it needs to be top-level"
+            )
+
     def render(self) -> str:
         # remove the leading '#' because we're in code mode
-        args = [self.body.render().lstrip("#")]
+        args = [utils.render(self.body).lstrip("#")]
         if self.placement is not None:
             args.append(f"placement: {self.placement}")
         if self.caption is not None:

--- a/pypst/renderable.py
+++ b/pypst/renderable.py
@@ -1,0 +1,14 @@
+from abc import ABC, abstractmethod
+
+
+class Renderable(ABC):
+    @abstractmethod
+    def render(self):
+        pass
+
+    @classmethod
+    def __subclasshook__(cls, subclass):
+        if cls is Renderable:
+            if any("render" in B.__dict__ for B in subclass.__mro__):
+                return True
+        return NotImplemented

--- a/pypst/renderable.py
+++ b/pypst/renderable.py
@@ -1,14 +1,16 @@
 from abc import ABC, abstractmethod
+from typing import Any
 
 
 class Renderable(ABC):
     @abstractmethod
-    def render(self):
+    def render(self) -> str:
         pass
 
     @classmethod
-    def __subclasshook__(cls, subclass):
+    def __subclasshook__(cls, subclass: Any) -> bool:
         if cls is Renderable:
             if any("render" in B.__dict__ for B in subclass.__mro__):
                 return True
+
         return NotImplemented

--- a/pypst/table.py
+++ b/pypst/table.py
@@ -8,7 +8,7 @@ from frozendict import frozendict
 from frozenlist import FrozenList
 
 from pypst.cell import Cell
-from pypst.utils import render_arg, render_mapping
+from pypst.utils import render_type, render_mapping
 
 
 @dataclass
@@ -266,28 +266,28 @@ class Table:
     def _render_args(self) -> str:
         args = []
         if self._columns is not None:
-            columns = render_arg(self._columns)
+            columns = render_type(self._columns)
             args.append(f"columns: {columns}")
         if self._rows is not None:
-            rows = render_arg(self._rows)
+            rows = render_type(self._rows)
             args.append(f"rows: {rows}")
         if self._stroke is not None:
-            stroke = render_arg(self._stroke)
+            stroke = render_type(self._stroke)
             args.append(f"stroke: {stroke}")
         if self._align is not None:
-            align = render_arg(self._align)
+            align = render_type(self._align)
             args.append(f"align: {align}")
         if self._fill is not None:
-            fill = render_arg(self._fill)
+            fill = render_type(self._fill)
             args.append(f"fill: {fill}")
         if self._gutter is not None:
-            gutter = render_arg(self._gutter)
+            gutter = render_type(self._gutter)
             args.append(f"gutter: {gutter}")
         if self._column_gutter is not None:
-            column_gutter = render_arg(self._column_gutter)
+            column_gutter = render_type(self._column_gutter)
             args.append(f"column-gutter: {column_gutter}")
         if self._row_gutter is not None:
-            row_gutter = render_arg(self._row_gutter)
+            row_gutter = render_type(self._row_gutter)
             args.append(f"row-gutter: {row_gutter}")
         rendered_args = ",\n".join(args) + ",\n"
 

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -1,7 +1,18 @@
 from typing import Sequence, Mapping, Iterable, Any
 
+from pypst.renderable import Renderable
 
-def render_arg(arg: int | str | Sequence[str] | Mapping[str, str]) -> str:
+
+def render(obj: Renderable | int | str | Sequence[str] | Mapping[str, str]) -> str:
+    if isinstance(obj, Renderable):
+        rendered = obj.render()
+    else:
+        rendered = render_type(obj)
+
+    return rendered
+
+
+def render_type(arg: int | str | Sequence[str] | Mapping[str, str]) -> str:
     if isinstance(arg, int | float):
         rendered_arg = str(arg)
     elif isinstance(arg, str):


### PR DESCRIPTION
This PR introduces the `Renderable` interface as a type for all classes that implement the `render` method.