### PR TITLE
feat: extend document class to hold multiple body items

### DIFF
--- a/pypst/document.py
+++ b/pypst/document.py
@@ -6,17 +6,20 @@ from pypst.renderable import Renderable
 
 
 class Document:
-    _body: Renderable | str | list[Renderable | str]
+    _body: list[Renderable | str]
     imports: list["Import"]
 
-    def __init__(self, body: Renderable | str | list[Renderable]) -> None:
+    def __init__(self, body: Renderable | str | list[Renderable | str]) -> None:
         self._body = []
         self.imports = []
 
-        self.add(body)
+        if not isinstance(body, list):
+            body = [body]
+        for b in body:
+            self.add(b)
 
     @property
-    def body(self):
+    def body(self) -> list[Renderable | str]:
         return self._body
 
     def add(self, body: Renderable | str) -> None:

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -10,6 +10,17 @@ def test_document(dummy_body):
     assert document.render() == "#text(fill: red)[Hello, world!]"
 
 
+def test_document_with_multiple_body_elements(dummy_body):
+    document = Document(dummy_body)
+    document.add("This is another text")
+    document.add(dummy_body)
+    assert document.render() == (
+        "#text(fill: red)[Hello, world!]\n"
+        "This is another text\n"
+        "#text(fill: red)[Hello, world!]"
+    )
+
+
 def test_document_with_imports(dummy_body):
     document = Document(dummy_body)
     document.add_import("@preview/cetz:0.2.2")


### PR DESCRIPTION
This PR makes it possible for `Document` to hold multiple body elements.
A separator newline is added between each rendered element