### PR TITLE
refactor: add element imports in root init file

### DIFF
--- a/pypst/__init__.py
+++ b/pypst/__init__.py
@@ -2,6 +2,18 @@ from pypst.table import Table
 from pypst.cell import Cell
 from pypst.figure import Figure
 from pypst.document import Document
+from pypst.heading import Heading
+from pypst.itemize import Itemize, Enumerate
+from pypst.image import Image
 
-__all__ = ["Table", "Cell", "Figure", "Document"]
+__all__ = [
+    "Table",
+    "Cell",
+    "Figure",
+    "Document",
+    "Heading",
+    "Itemize",
+    "Enumerate",
+    "Image",
+]
 __version__ = "0.1.0"


### PR DESCRIPTION
This PR imports all new elements in the root init file to make them available in the `pypst` namespace.