### PR TITLE
refactor: make creating empty documents possible

### DIFF
--- a/pypst/document.py
+++ b/pypst/document.py
@@ -9,11 +9,15 @@ class Document:
     _body: list[Renderable | str]
     imports: list["Import"]
 
-    def __init__(self, body: Renderable | str | list[Renderable | str]) -> None:
+    def __init__(
+        self, body: Optional[Renderable | str | list[Renderable | str]]
+    ) -> None:
         self._body = []
         self.imports = []
 
-        if not isinstance(body, list):
+        if body is None:
+            body = []
+        elif not isinstance(body, list):
             body = [body]
         for b in body:
             self.add(b)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -5,6 +5,13 @@ from pypst.figure import Figure
 from pypst.document import Document, Import
 
 
+def test_empty_document():
+    document = Document(None)
+
+    assert len(document.body) == 0
+    assert document.render() == ""
+
+
 def test_document(dummy_body):
     document = Document(dummy_body)
     assert document.render() == "#text(fill: red)[Hello, world!]"


### PR DESCRIPTION
This PR makes it possible to create documents without supplying a body.
This way, it can be added later dynamically via the `add` method.