### PR TITLE
feat: add Plain import

### DIFF
--- a/pypst/__init__.py
+++ b/pypst/__init__.py
@@ -5,6 +5,7 @@ from pypst.document import Document
 from pypst.heading import Heading
 from pypst.itemize import Itemize, Enumerate
 from pypst.image import Image
+from pypst.renderable import Renderable, Plain
 
 __all__ = [
     "Table",
@@ -15,5 +16,7 @@ __all__ = [
     "Itemize",
     "Enumerate",
     "Image",
+    "Renderable",
+    "Plain",
 ]
 __version__ = "0.2.0"

--- a/pypst/document.py
+++ b/pypst/document.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from pypst import utils
-from pypst.renderable import Renderable
+from pypst.renderable import Plain, Renderable
 
 
 class Document:
@@ -92,10 +92,14 @@ class Document:
         else:
             self._body.append(element)
 
-    def add_import(self, module: str, members: Optional[list[str]] = None) -> None:
+    def add_import(
+        self, module: str | Plain, members: Optional[list[str]] = None
+    ) -> None:
         """
         Add an import to the document.
 
+        The module is wrapped in quotes upon rendering by default,
+        but can be replaced by a `Plain` value to facilitate imports from a module value.
         If members are provided,
         only those members will be imported as `#import <module>: <list of members>`.
         If no members are provided, the entire module will be imported as
@@ -130,12 +134,31 @@ class Document:
 
 @dataclass
 class Import:
-    module: str
+    """
+    Typst import statement to add to the document.
+
+    The module is wrapped in quotes upon rendering by default,
+        but can be replaced by a `Plain` value to facilitate imports from a module value.
+        If members are provided,
+        only those members will be imported as `#import <module>: <list of members>`.
+        If no members are provided, the entire module will be imported as
+        `#import <module>`.
+        Imports are rendered at the top of the document.
+
+        Args:
+            module: The module to import.
+            members: The optional list of members to import.
+    """
+
+    module: str | Plain
     members: list[str] = field(default_factory=list)
 
     def render(self) -> str:
-        module = self.module.strip('"')
-        module = f'"{module}"'
+        if isinstance(self.module, Plain):
+            module = self.module.render()
+        else:
+            module = self.module.strip('"')
+            module = f'"{module}"'
         rendered_import = f"#import {module}"
         if self.members:
             if "*" in self.members and len(self.members) > 1:

--- a/pypst/document.py
+++ b/pypst/document.py
@@ -138,16 +138,16 @@ class Import:
     Typst import statement to add to the document.
 
     The module is wrapped in quotes upon rendering by default,
-        but can be replaced by a `Plain` value to facilitate imports from a module value.
-        If members are provided,
-        only those members will be imported as `#import <module>: <list of members>`.
-        If no members are provided, the entire module will be imported as
-        `#import <module>`.
-        Imports are rendered at the top of the document.
+    but can be replaced by a `Plain` value to facilitate imports from a module value.
+    If members are provided,
+    only those members will be imported as `#import <module>: <list of members>`.
+    If no members are provided, the entire module will be imported as
+    `#import <module>`.
+    Imports are rendered at the top of the document.
 
-        Args:
-            module: The module to import.
-            members: The optional list of members to import.
+    Args:
+        module: The module to import.
+        members: The optional list of members to import.
     """
 
     module: str | Plain

--- a/pypst/renderable.py
+++ b/pypst/renderable.py
@@ -1,8 +1,15 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Any
 
 
 class Renderable(ABC):
+    """
+    Abstract base class for any renderable object.
+
+    Any Typst document element should inherit/implement this abstract base class.
+    """
+
     @abstractmethod
     def render(self) -> str:
         pass
@@ -14,3 +21,22 @@ class Renderable(ABC):
                 return True
 
         return NotImplemented
+
+
+@dataclass
+class Plain:
+    """
+    Plain string content that is rendered as-is.
+
+    """
+
+    value: str
+
+    def render(self) -> str:
+        """
+        Render the internal string value as-is.
+
+        Returns:
+            The internal string value as-is.
+        """
+        return self.value

--- a/pypst/renderable.py
+++ b/pypst/renderable.py
@@ -27,7 +27,6 @@ class Renderable(ABC):
 class Plain:
     """
     Plain string content that is rendered as-is.
-
     """
 
     value: str

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3,6 +3,7 @@ import typst
 
 from pypst.figure import Figure
 from pypst.document import Document, Import
+from pypst.renderable import Plain
 
 
 def test_empty_document():
@@ -31,8 +32,11 @@ def test_document_with_multiple_body_elements(dummy_body):
 def test_document_with_imports(dummy_body):
     document = Document(dummy_body)
     document.add_import("@preview/cetz:0.2.2")
+    document.add_import(Plain("cetz.draw"), members=["*"])
     assert document.render() == (
-        '#import "@preview/cetz:0.2.2"\n\n' "#text(fill: red)[Hello, world!]"
+        '#import "@preview/cetz:0.2.2"\n'
+        "#import cetz.draw: *\n\n"
+        "#text(fill: red)[Hello, world!]"
     )
 
 
@@ -60,7 +64,20 @@ class TestImport:
         imp = Import('"todo.typ"')
         assert imp.render() == '#import "todo.typ"'
 
+    def test_plain_import(self):
+        imp = Import(Plain("todo.task"))
+        assert imp.render() == "#import todo.task"
+
+    def test_plain_import_with_members(self):
+        imp = Import(Plain("todo.task"), "*")
+        assert imp.render() == "#import todo.task: *"
+
     def test_faulty_import(self):
         imp = Import("todo.typ", ["*", "task"])
+        with pytest.raises(ValueError):
+            imp.render()
+
+    def test_faulty_plain_import(self):
+        imp = Import(Plain("todo"), ["*", "task"])
         with pytest.raises(ValueError):
             imp.render()

--- a/tests/test_renderable.py
+++ b/tests/test_renderable.py
@@ -1,0 +1,20 @@
+from pypst.renderable import Plain, Renderable
+
+
+def test_renderable():
+    class Foo:
+        pass
+
+    class Bar:
+        def render() -> str:
+            pass
+
+    assert not issubclass(Foo, Renderable)
+    assert issubclass(Bar, Renderable)
+    assert not isinstance(Foo(), Renderable)
+    assert isinstance(Bar(), Renderable)
+
+
+def test_plain():
+    plain = Plain("Lorem ipsum dolor sit amet.")
+    assert plain.render() == "Lorem ipsum dolor sit amet."


### PR DESCRIPTION
Adds the Plain import option to facilitate module value imports. 

Closes #14 