### PR TITLE
Additional rendering utils

### DIFF
--- a/pypst/figure.py
+++ b/pypst/figure.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass, field
 from typing import Literal
 
-from pypst import utils
 from pypst.document import Document
 from pypst.renderable import Renderable
+from pypst.utils import RenderDataclass
 
 
 @dataclass
-class Figure(utils.Function):
+class Figure(RenderDataclass):
     """
     A figure is a block element that contains another element.
 
@@ -33,6 +33,8 @@ class Figure(utils.Function):
         >>> print(fig.render())
         #figure(image("image.png"), caption: [This is an image.])
     """
+
+    __is_function__ = True
 
     body: Renderable | str = field(metadata={"positional": True})
 

--- a/pypst/figure.py
+++ b/pypst/figure.py
@@ -3,11 +3,11 @@ from typing import Literal
 
 from pypst.document import Document
 from pypst.renderable import Renderable
-from pypst.utils import RenderDataclass
+from pypst.utils import Function
 
 
 @dataclass
-class Figure(RenderDataclass):
+class Figure(Function):
     """
     A figure is a block element that contains another element.
 

--- a/pypst/figure.py
+++ b/pypst/figure.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
-from typing import Optional, Literal
+from dataclasses import dataclass, field
+from typing import Literal
 
 from pypst import utils
 from pypst.document import Document
@@ -7,7 +7,7 @@ from pypst.renderable import Renderable
 
 
 @dataclass
-class Figure:
+class Figure(utils.Function):
     """
     A figure is a block element that contains another element.
 
@@ -26,29 +26,23 @@ class Figure:
     Examples:
         >>> fig = Figure("[Hello, World!]", caption="[This is content.]")
         >>> print(fig.render())
-        #figure(
-          [Hello, World!],
-          caption: [This is content.]
-        )
+        #figure([Hello, World!], caption: [This is content.])
 
         >>> from pypst import Image
         >>> fig = Figure(Image("image.png"), caption="[This is an image.]")
         >>> print(fig.render())
-        #figure(
-          image("image.png"),
-          caption: [This is an image.]
-        )
+        #figure(image("image.png"), caption: [This is an image.])
     """
 
-    body: Renderable | str
+    body: Renderable | str = field(metadata={"positional": True})
 
-    placement: Optional[Literal["auto", "top", "bottom"]] = None
-    caption: Optional[str] = None
-    kind: Optional[str] = None
-    supplement: Optional[str] = None
-    numbering: Optional[str] = None
-    gap: Optional[str] = None
-    outlined: Optional[bool] = None
+    placement: Literal["auto", "top", "bottom"] | None = None
+    caption: Renderable | str | None = None
+    kind: Renderable | str | None = None
+    supplement: Renderable | str | None = None
+    numbering: Renderable | str | None = None
+    gap: Renderable | str | None = None
+    outlined: bool | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.body, (Renderable, str)):
@@ -57,34 +51,3 @@ class Figure:
             raise ValueError(
                 "Document cannot be set as body, because it needs to be top-level"
             )
-
-    def render(self) -> str:
-        """
-        Render the figure.
-
-        The body and attributes of the figure is indented by two spaces.
-
-        Returns:
-            The rendered figure.
-        """
-        # remove the leading '#' because we're in code mode
-        args = [utils.render(self.body).lstrip("#")]
-        if self.placement is not None:
-            args.append(f"placement: {self.placement}")
-        if self.caption is not None:
-            args.append(f"caption: {self.caption}")
-        if self.kind is not None:
-            args.append(f"kind: {self.kind}")
-        if self.supplement is not None:
-            args.append(f"supplement: {self.supplement}")
-        if self.numbering is not None:
-            args.append(f"numbering: {self.numbering}")
-        if self.gap is not None:
-            args.append(f"gap: {self.gap}")
-        if self.outlined is not None:
-            args.append(f"outlined: {'true' if self.outlined else 'false'}")
-
-        # indent body and args by 2 spaces
-        inner = ",\n".join(args).replace("\n", "\n  ")
-
-        return "#figure(\n  {0}\n)".format(inner)

--- a/pypst/heading.py
+++ b/pypst/heading.py
@@ -1,5 +1,4 @@
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
 
 from pypst import utils
 from pypst.document import Document
@@ -7,7 +6,7 @@ from pypst.renderable import Renderable
 
 
 @dataclass
-class Heading:
+class Heading(utils.Function):
     """
     A Heading element.
 
@@ -40,14 +39,14 @@ class Heading:
         #heading("Heading 1", depth: 2, offset: 1)
     """
 
-    body: Renderable | str
-    level: Optional[int] = None
-    depth: Optional[int] = None
-    offset: Optional[int] = None
-    numbering: Optional[str] = None
-    supplement: Optional[Renderable | str] = None
-    outlined: Optional[bool] = None
-    bookmarked: Optional[bool] = None
+    body: Renderable | str = field(metadata={"positional": True})
+    level: int | None = None
+    depth: int | None = None
+    offset: int | None = None
+    numbering: str | None = None
+    supplement: Renderable | str | None = None
+    outlined: bool | None = None
+    bookmarked: bool | None = None
 
     def __post_init__(self) -> None:
         if self.level is not None and self.level < 1:
@@ -78,28 +77,9 @@ class Heading:
         Returns:
             The rendered heading element.
         """
-        args = [utils.render(self.body)]
-        if self.level is not None:
-            args.append(f"level: {self.level}")
-        if self.depth is not None:
-            args.append(f"depth: {self.depth}")
-        if self.offset is not None:
-            args.append(f"offset: {self.offset}")
-        if self.numbering is not None:
-            args.append(f"numbering: {self.numbering}")
-        if self.supplement is not None:
-            args.append(f"supplement: {utils.render(self.supplement)}")
-        if self.outlined is not None:
-            args.append(f"outlined: {utils.render(self.outlined)}")
-        if self.bookmarked is not None:
-            args.append(f"bookmarked: {utils.render(self.bookmarked)}")
-
-        if self.level is not None and len(args) == 2:
+        if self.level is not None and len(list(self.fields_to_render())) == 2:
             # remove unnecessary quotes, because Markdown style is not in code mode
-            body = args[0].strip('"')
-            heading = "=" * self.level + f" {body}"
+            body = self.body.strip('"')
+            return "=" * self.level + f" {body}"
         else:
-            args[0] = args[0].lstrip("#")  # remove hashtag because of code mode
-            heading = f"#heading({', '.join(args)})"
-
-        return heading
+            return super().render()

--- a/pypst/heading.py
+++ b/pypst/heading.py
@@ -2,11 +2,11 @@ from dataclasses import dataclass, field
 
 from pypst.document import Document
 from pypst.renderable import Renderable
-from pypst.utils import RenderDataclass, dataclass_fields_to_render
+from pypst.utils import Function, dataclass_fields_to_render
 
 
 @dataclass
-class Heading(RenderDataclass):
+class Heading(Function):
     """
     A Heading element.
 

--- a/pypst/heading.py
+++ b/pypst/heading.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 
 from pypst.document import Document
 from pypst.renderable import Renderable
-from pypst.utils import Function, dataclass_fields_to_render
+from pypst.utils import Function, dataclass_fields_to_render, render
 
 
 @dataclass
@@ -81,7 +81,7 @@ class Heading(Function):
         """
         if self.level is not None and len(list(dataclass_fields_to_render(self))) == 2:
             # remove unnecessary quotes, because Markdown style is not in code mode
-            body = self.body.strip('"')
-            return "=" * self.level + f" {body}"
+            body = render(self.body).strip('"')
+            return f"{'=' * self.level} {body}"
         else:
             return super().render()

--- a/pypst/heading.py
+++ b/pypst/heading.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass, field
 
-from pypst import utils
 from pypst.document import Document
 from pypst.renderable import Renderable
+from pypst.utils import RenderDataclass, dataclass_fields_to_render
 
 
 @dataclass
-class Heading(utils.Function):
+class Heading(RenderDataclass):
     """
     A Heading element.
 
@@ -38,6 +38,8 @@ class Heading(utils.Function):
         >>> print(h.render())
         #heading("Heading 1", depth: 2, offset: 1)
     """
+
+    __is_function__ = True
 
     body: Renderable | str = field(metadata={"positional": True})
     level: int | None = None
@@ -77,7 +79,7 @@ class Heading(utils.Function):
         Returns:
             The rendered heading element.
         """
-        if self.level is not None and len(list(self.fields_to_render())) == 2:
+        if self.level is not None and len(list(dataclass_fields_to_render(self))) == 2:
             # remove unnecessary quotes, because Markdown style is not in code mode
             body = self.body.strip('"')
             return "=" * self.level + f" {body}"

--- a/pypst/image.py
+++ b/pypst/image.py
@@ -1,9 +1,11 @@
-from dataclasses import dataclass
-from typing import Optional, Literal
+from dataclasses import dataclass, field
+from typing import Literal
+
+from pypst.utils import Function
 
 
 @dataclass
-class Image:
+class Image(Function):
     """
     Image object to add image elements.
 
@@ -24,32 +26,19 @@ class Image:
         #image("image.png", width: 100%, height: 50%)
     """
 
-    path: str
-    format: Optional[Literal["png", "jpg", "gif", "svg"]] = None
-    width: Optional[str] = None
-    height: Optional[str] = None
-    alt: Optional[str] = None
-    fit: Optional[Literal["cover", "contain", "stretch"]] = None
+    path: str = field(metadata={"positional": True})
+    format: Literal["png", "jpg", "gif", "svg"] | None = None
+    width: str | None = None
+    height: str | None = None
+    alt: str | None = None
+    fit: Literal["cover", "contain", "stretch"] | None = None
 
-    def render(self) -> str:
-        """
-        Render the image element to a string.
+    def __post_init__(self):
+        if not self.path.startswith('"'):
+            self.path = f'"{self.path}"'
 
-        Returns:
-            The rendered image element.
-        """
-        path = self.path if self.path.startswith('"') else f'"{self.path}"'
-        args = [path]
-        if self.format is not None:
-            args.append(f'format: "{self.format}"')
-        if self.width is not None:
-            args.append(f"width: {self.width}")
-        if self.height is not None:
-            args.append(f"height: {self.height}")
-        if self.alt is not None:
-            args.append(f"alt: {self.alt}")
-        if self.fit is not None:
-            args.append(f'fit: "{self.fit}"')
-        rendered = f"#image({', '.join(args)})"
+        if self.format is not None and not self.format.startswith('"'):
+            self.format = f'"{self.format}"'
 
-        return rendered
+        if self.fit is not None and not self.fit.startswith('"'):
+            self.fit = f'"{self.fit}"'

--- a/pypst/image.py
+++ b/pypst/image.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass, field
 from typing import Literal
 
-from pypst.utils import RenderDataclass
+from pypst.utils import Function
 
 
 @dataclass
-class Image(RenderDataclass):
+class Image(Function):
     """
     Image object to add image elements.
 

--- a/pypst/image.py
+++ b/pypst/image.py
@@ -29,13 +29,13 @@ class Image(Function):
     __is_function__ = True
 
     path: str = field(metadata={"positional": True})
-    format: Literal["png", "jpg", "gif", "svg"] | None = None
+    format: Literal["png", "jpg", "gif", "svg"] | str | None = None
     width: str | None = None
     height: str | None = None
     alt: str | None = None
-    fit: Literal["cover", "contain", "stretch"] | None = None
+    fit: Literal["cover", "contain", "stretch"] | str | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if not self.path.startswith('"'):
             self.path = f'"{self.path}"'
 

--- a/pypst/image.py
+++ b/pypst/image.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass, field
 from typing import Literal
 
-from pypst.utils import Function
+from pypst.utils import RenderDataclass
 
 
 @dataclass
-class Image(Function):
+class Image(RenderDataclass):
     """
     Image object to add image elements.
 
@@ -25,6 +25,8 @@ class Image(Function):
         >>> print(image.render())
         #image("image.png", width: 100%, height: 50%)
     """
+
+    __is_function__ = True
 
     path: str = field(metadata={"positional": True})
     format: Literal["png", "jpg", "gif", "svg"] | None = None

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -165,9 +165,10 @@ class Dictionary:
 
         Modify `field_to_render` to control which fields are included.
         """
-        return f"#{render_mapping(
+        mapping = render_mapping(
             {field.name: getattr(self, field.name) for field in self.fields_to_render()}
-        )}"
+        )
+        return f"#{mapping}"
 
     def fields_to_render(self) -> Iterable[Field]:
         """

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -155,11 +155,13 @@ class RenderDataclass:
 @dataclass
 class Function:
     """
-    Helper class to render Typst function calls.
+    Helper class to render Typst function calls from a Python dataclass.
 
     Inherit from `Function` to inherit the render method.
     The function name is derived from the class name
     and is converted to kebab-case.
+
+    The dataclass' fields are used as the function arguments.
 
     You can specify a positional argument in Typst by adding
     `positional=True` on the dataclass field's metadata.

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import date, datetime, timedelta
 from typing import Any
+
 from pypst.renderable import Renderable
 
 
@@ -119,12 +120,11 @@ def render_timedelta(arg: timedelta) -> str:
     obj = {
         name: getattr(arg, name)
         for name in [
+            "microseconds",
             "seconds",
-            "minutes",
-            "hours",
             "days",
-            "weeks",
         ]
         if hasattr(arg, name)
     }
+    obj["seconds"] = obj["seconds"] + round(obj.pop("milliseconds") / 1e6)
     return f"#duration{render_mapping(obj)}"

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -1,8 +1,8 @@
+import re
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass, fields
+from dataclasses import Field, dataclass, fields
 from datetime import date, datetime, timedelta
 from typing import Any
-import re
 
 from pypst.renderable import Renderable
 
@@ -133,7 +133,7 @@ def render_timedelta(arg: timedelta) -> str:
 
 
 @dataclass
-class RenderDataclass:
+class Dictionary:
     """
     Helper class to render Python dataclasses by iterating over its fields
     as if it were a dictionary.
@@ -147,9 +147,21 @@ class RenderDataclass:
         Dataclass rendering using fields iteration
         and recursively using Pypst rendering.
         """
-        return render_mapping(
-            {field.name: getattr(self, field.name) for field in fields(self)}
-        )
+        return f"#{render_mapping(
+            {field.name: getattr(self, field.name) for field in self.fields_to_render()}
+        )}"
+
+    def fields_to_render(self) -> Iterable[Field]:
+        """
+        These fields should be rendered. Defaults to skipping any fields with a value of `None`.
+        """
+
+        def check(field: Field):
+            if getattr(self, field.name) is None:
+                return field.metadata.get("keep_none", False)
+            return True
+
+        return filter(check, fields(self))
 
 
 @dataclass
@@ -164,17 +176,24 @@ class Function:
     The dataclass' fields are used as the function arguments.
 
     You can specify a positional argument in Typst by adding
-    `positional=True` on the dataclass field's metadata.
+    `positional=True` on the field's metadata.
+
+    You can specify that `None` values should be rendered instead
+    of being skipped with `keep_none=True` on the field's metadata.
 
     Example:
         >>> from dataclasses import dataclass, field
         >>> @dataclass
         ... class FooFn(Function):
-        ...    bar: int = field(metadata={"positional": True})
-        ...    qux: int = 16
+        ...    bar: int | None = field(metadata={"positional": True})
+        ...    qux: int | None = field(default=16, metadata={"keep_none": True})
         >>>
         >>> FooFn(4).render()
         '#foo-fn(4, qux: 16)'
+        >>> FooFn(None).render()
+        '#foo-fn(qux: 16)'
+        >>> FooFn(4, qux=None).render()
+        '#foo-fn(4, qux: none)'
     """
 
     def render(self) -> str:
@@ -189,6 +208,18 @@ class Function:
             render_code(getattr(self, field.name))
             if field.metadata.get("positional", False)
             else f"{field.name}: {render_code(getattr(self, field.name))}"
-            for field in fields(self)
+            for field in self.fields_to_render()
         )
         return f"#{function}({options})"
+
+    def fields_to_render(self) -> Iterable[Field]:
+        """
+        These fields should be rendered. Defaults to skipping any fields with a value of `None`.
+        """
+
+        def check(field: Field):
+            if getattr(self, field.name) is None:
+                return field.metadata.get("keep_none", False)
+            return True
+
+        return filter(check, fields(self))

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Mapping, Sequence
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Any
 from pypst.renderable import Renderable
 
@@ -14,6 +14,7 @@ def render(
     | Mapping[str, Any]
     | date
     | datetime
+    | timedelta
     | None,
 ) -> str:
     """
@@ -38,6 +39,7 @@ def render_code(
     | Mapping[str, Any]
     | date
     | datetime
+    | timedelta
     | None,
 ) -> str:
     """
@@ -56,6 +58,7 @@ def render_type(
     | Mapping[str, Any]
     | date
     | datetime
+    | timedelta
     | None,
 ) -> str:
     """
@@ -75,6 +78,8 @@ def render_type(
         rendered_arg = render_mapping(arg)
     elif isinstance(arg, date):
         rendered_arg = render_date(arg)
+    elif isinstance(arg, timedelta):
+        rendered_arg = render_timedelta(arg)
     else:
         raise ValueError(f"Invalid argument type: {type(arg)}")
 
@@ -105,3 +110,21 @@ def render_date(arg: date) -> str:
         if hasattr(arg, name)
     }
     return f"#datetime{render_mapping(obj)}"
+
+
+def render_timedelta(arg: timedelta) -> str:
+    """
+    Render a Python `datetime.timedelta` into a call to the Typst duration function.
+    """
+    obj = {
+        name: getattr(arg, name)
+        for name in [
+            "seconds",
+            "minutes",
+            "hours",
+            "days",
+            "weeks",
+        ]
+        if hasattr(arg, name)
+    }
+    return f"#duration{render_mapping(obj)}"

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -12,7 +12,6 @@ def render(
     | str
     | Sequence[Any]
     | Mapping[str, Any]
-    | date
     | datetime
     | timedelta
     | None,
@@ -77,7 +76,7 @@ def render_type(
     elif isinstance(arg, Mapping):
         rendered_arg = render_mapping(arg)
     elif isinstance(arg, date):
-        rendered_arg = render_date(arg)
+        rendered_arg = render_datetime(arg)
     elif isinstance(arg, timedelta):
         rendered_arg = render_timedelta(arg)
     else:
@@ -100,7 +99,7 @@ def render_sequence(arg: Iterable[Any]) -> str:
     return f"({', '.join(render_code(a) for a in arg)})"
 
 
-def render_date(arg: date) -> str:
+def render_datetime(arg: date) -> str:
     """
     Render a Python `datetime.date` into a call to the Typst datetime function.
     """

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable, Mapping, Sequence
+from datetime import date, datetime
 from typing import Any
 from pypst.renderable import Renderable
 
@@ -11,6 +12,8 @@ def render(
     | str
     | Sequence[Any]
     | Mapping[str, Any]
+    | date
+    | datetime
     | None,
 ) -> str:
     """
@@ -33,6 +36,8 @@ def render_code(
     | str
     | Sequence[Any]
     | Mapping[str, Any]
+    | date
+    | datetime
     | None,
 ) -> str:
     """
@@ -43,12 +48,22 @@ def render_code(
 
 
 def render_type(
-    arg: bool | int | float | str | Sequence[Any] | Mapping[str, Any] | None,
+    arg: bool
+    | int
+    | float
+    | str
+    | Sequence[Any]
+    | Mapping[str, Any]
+    | date
+    | datetime
+    | None,
 ) -> str:
     """
     Render different built-in Python types.
     """
-    if isinstance(arg, bool):
+    if arg is None:
+        rendered_arg = "none"
+    elif isinstance(arg, bool):
         rendered_arg = str(arg).lower()
     elif isinstance(arg, int | float):
         rendered_arg = str(arg)
@@ -58,8 +73,8 @@ def render_type(
         rendered_arg = render_sequence(arg)
     elif isinstance(arg, Mapping):
         rendered_arg = render_mapping(arg)
-    elif arg is None:
-        rendered_arg = "none"
+    elif isinstance(arg, date):
+        rendered_arg = render_date(arg)
     else:
         raise ValueError(f"Invalid argument type: {type(arg)}")
 
@@ -78,3 +93,15 @@ def render_sequence(arg: Iterable[Any]) -> str:
     Render a sequence of any object supported by `render`.
     """
     return f"({', '.join(render_code(a) for a in arg)})"
+
+
+def render_date(arg: date) -> str:
+    """
+    Render a Python `datetime.date` into a call to the Typst datetime function.
+    """
+    obj = {
+        name: getattr(arg, name)
+        for name in ["year", "month", "day", "hour", "minute", "second"]
+        if hasattr(arg, name)
+    }
+    return f"#datetime{render_mapping(obj)}"

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -12,6 +12,7 @@ def render(
     | str
     | Sequence[Any]
     | Mapping[str, Any]
+    | date
     | datetime
     | timedelta
     | None,
@@ -99,7 +100,7 @@ def render_sequence(arg: Iterable[Any]) -> str:
     return f"({', '.join(render_code(a) for a in arg)})"
 
 
-def render_datetime(arg: date) -> str:
+def render_datetime(arg: date | datetime) -> str:
     """
     Render a Python `datetime.date` into a call to the Typst datetime function.
     """

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -138,14 +138,32 @@ class Dictionary:
     Helper class to render Python dataclasses by iterating over its fields
     as if it were a dictionary.
 
-    Inherit from `RenderDataclass` to inherit the render method
-    and stick it on your dataclass.
+    Inherit from `Dictionary` to inherit the render method
+    and use it with your dataclass.
+
+    You can specify that `None` values should be rendered instead
+    of being skipped with `keep_none=True` on the field's metadata.
+
+    Example:
+        >>> from dataclasses import dataclass, field
+        >>> @dataclass
+        ... class Foo(Dictionary):
+        ...    bar: int | None = 4
+        ...    qux: int | None = field(default=16, metadata={"keep_none": True})
+        >>>
+        >>> Foo().render()
+        '#(bar: 4, qux: 16)'
+        >>> Foo(bar=None).render()
+        '#(qux: 16)'
+        >>> Foo(qux=None).render()
+        '#(bar: 4, qux: none)'
     """
 
     def render(self) -> str:
         """
-        Dataclass rendering using fields iteration
-        and recursively using Pypst rendering.
+        Dataclass rendering to a Typst dictionary.
+
+        Modify `field_to_render` to control which fields are included.
         """
         return f"#{render_mapping(
             {field.name: getattr(self, field.name) for field in self.fields_to_render()}
@@ -156,7 +174,7 @@ class Dictionary:
         These fields should be rendered. Defaults to skipping any fields with a value of `None`.
         """
 
-        def check(field: Field):
+        def check(field: Field) -> bool:
             if getattr(self, field.name) is None:
                 return field.metadata.get("keep_none", False)
             return True
@@ -165,7 +183,7 @@ class Dictionary:
 
 
 @dataclass
-class Function:
+class Function(Dictionary):
     """
     Helper class to render Typst function calls from a Python dataclass.
 
@@ -198,7 +216,9 @@ class Function:
 
     def render(self) -> str:
         """
-        Dataclass rendering to generate a function call.
+        Dataclass rendering to a Typst function call.
+
+        Modify `field_to_render` to control which fields are included.
         """
         # kebab-case the ClassName
         function = re.sub(
@@ -211,15 +231,3 @@ class Function:
             for field in self.fields_to_render()
         )
         return f"#{function}({options})"
-
-    def fields_to_render(self) -> Iterable[Field]:
-        """
-        These fields should be rendered. Defaults to skipping any fields with a value of `None`.
-        """
-
-        def check(field: Field):
-            if getattr(self, field.name) is None:
-                return field.metadata.get("keep_none", False)
-            return True
-
-        return filter(check, fields(self))

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -4,7 +4,14 @@ from pypst.renderable import Renderable
 
 
 def render(
-    obj: Renderable | bool | int | float | str | Sequence[Any] | Mapping[str, Any],
+    obj: Renderable
+    | bool
+    | int
+    | float
+    | str
+    | Sequence[Any]
+    | Mapping[str, Any]
+    | None,
 ) -> str:
     """
     Render renderable objects using their `render` method
@@ -19,7 +26,14 @@ def render(
 
 
 def render_code(
-    obj: Renderable | bool | int | float | str | Sequence[Any] | Mapping[str, Any],
+    obj: Renderable
+    | bool
+    | int
+    | float
+    | str
+    | Sequence[Any]
+    | Mapping[str, Any]
+    | None,
 ) -> str:
     """
     Render renderable objects using the `render` method
@@ -29,7 +43,7 @@ def render_code(
 
 
 def render_type(
-    arg: bool | int | float | str | Sequence[Any] | Mapping[str, Any],
+    arg: bool | int | float | str | Sequence[Any] | Mapping[str, Any] | None,
 ) -> str:
     """
     Render different built-in Python types.
@@ -44,6 +58,8 @@ def render_type(
         rendered_arg = render_sequence(arg)
     elif isinstance(arg, Mapping):
         rendered_arg = render_mapping(arg)
+    elif arg is None:
+        rendered_arg = "none"
     else:
         raise ValueError(f"Invalid argument type: {type(arg)}")
 

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, fields
 from datetime import date, datetime, timedelta
 from typing import Any
 
@@ -128,3 +129,23 @@ def render_timedelta(arg: timedelta) -> str:
     }
     obj["seconds"] = obj["seconds"] + round(obj.pop("milliseconds") / 1e6)
     return f"#duration{render_mapping(obj)}"
+
+
+@dataclass
+class RenderDataclass:
+    """
+    Helper class to render Python dataclasses by iterating over its fields
+    as if it were a dictionary.
+
+    Inherit from `RenderDataclass` to inherit the render method
+    and stick it on your dataclass.
+    """
+
+    def render(self):
+        """
+        Dataclass rendering using fields iteration
+        and recursively using Pypst rendering.
+        """
+        return render_mapping(
+            {field.name: render(getattr(self, field.name)) for field in fields(self)}
+        )

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -163,7 +163,7 @@ class Dictionary:
         """
         Dataclass rendering to a Typst dictionary.
 
-        Modify `field_to_render` to control which fields are included.
+        Modify `fields_to_render` to control which fields are included.
         """
         mapping = render_mapping(
             {field.name: getattr(self, field.name) for field in self.fields_to_render()}
@@ -219,7 +219,7 @@ class Function(Dictionary):
         """
         Dataclass rendering to a Typst function call.
 
-        Modify `field_to_render` to control which fields are included.
+        Modify `fields_to_render` to control which fields are included.
         """
         # kebab-case the ClassName
         function = re.sub(

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, fields
 from datetime import date, datetime, timedelta
 from typing import Any
+import re
 
 from pypst.renderable import Renderable
 
@@ -127,7 +128,7 @@ def render_timedelta(arg: timedelta) -> str:
         ]
         if hasattr(arg, name)
     }
-    obj["seconds"] = obj["seconds"] + round(obj.pop("milliseconds") / 1e6)
+    obj["seconds"] = obj["seconds"] + round(obj.pop("microseconds") / 1e6)
     return f"#duration{render_mapping(obj)}"
 
 
@@ -141,11 +142,51 @@ class RenderDataclass:
     and stick it on your dataclass.
     """
 
-    def render(self):
+    def render(self) -> str:
         """
         Dataclass rendering using fields iteration
         and recursively using Pypst rendering.
         """
         return render_mapping(
-            {field.name: render(getattr(self, field.name)) for field in fields(self)}
+            {field.name: getattr(self, field.name) for field in fields(self)}
         )
+
+
+@dataclass
+class Function:
+    """
+    Helper class to render Typst function calls.
+
+    Inherit from `Function` to inherit the render method.
+    The function name is derived from the class name
+    and is converted to kebab-case.
+
+    You can specify a positional argument in Typst by adding
+    `positional=True` on the dataclass field's metadata.
+
+    Example:
+        >>> from dataclasses import dataclass, field
+        >>> @dataclass
+        ... class FooFn(Function):
+        ...    bar: int = field(metadata={"positional": True})
+        ...    qux: int = 16
+        >>>
+        >>> FooFn(4).render()
+        '#foo-fn(4, qux: 16)'
+    """
+
+    def render(self) -> str:
+        """
+        Dataclass rendering to generate a function call.
+        """
+        # kebab-case the ClassName
+        function = re.sub(
+            r"([a-z0-9])([A-Z])", r"\1-\2", self.__class__.__name__
+        ).lower()
+        options = ", ".join(
+            render_code(getattr(self, field.name))
+            if field.metadata.get("positional", False)
+            else f"{field.name}: {render_code(getattr(self, field.name))}"
+            for field in fields(self)
+        )
+        return f"#{function}({options})"

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -159,6 +159,9 @@ class Dictionary:
         '#(bar: 4, qux: none)'
     """
 
+    def __str__(self) -> str:
+        return self.render()
+
     def render(self) -> str:
         """
         Dataclass rendering to a Typst dictionary.
@@ -176,8 +179,11 @@ class Dictionary:
         """
 
         def check(field: Field) -> bool:
+            # When the value is `None`, check whether that should be kept.
             if getattr(self, field.name) is None:
                 return field.metadata.get("keep_none", False)
+
+            # Keep otherwise.
             return True
 
         return filter(check, fields(self))
@@ -221,14 +227,27 @@ class Function(Dictionary):
 
         Modify `fields_to_render` to control which fields are included.
         """
-        # kebab-case the ClassName
-        function = re.sub(
-            r"([a-z0-9])([A-Z])", r"\1-\2", self.__class__.__name__
-        ).lower()
+
+        function = self.function()
+
         options = ", ".join(
             render_code(getattr(self, field.name))
             if field.metadata.get("positional", False)
             else f"{field.name}: {render_code(getattr(self, field.name))}"
             for field in self.fields_to_render()
         )
+
         return f"#{function}({options})"
+
+    @classmethod
+    def function(cls) -> str:
+        """
+        Class method that returns the Typst function name that it represents.
+
+        Defaults to a kebab-case transformation of the ClassName.
+        """
+        return re.sub(
+            r"([a-z0-9])([A-Z])",
+            r"\1-\2",
+            cls.__name__,
+        ).lower()

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -1,6 +1,6 @@
 import re
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import Field, dataclass, fields, is_dataclass
+from dataclasses import Field, fields, is_dataclass
 from datetime import date, datetime, timedelta
 from typing import Any
 

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -1,6 +1,6 @@
 import re
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import Field, dataclass, fields
+from dataclasses import Field, dataclass, fields, is_dataclass
 from datetime import date, datetime, timedelta
 from typing import Any
 
@@ -77,6 +77,8 @@ def render_type(
         rendered_arg = arg
     elif isinstance(arg, Sequence):
         rendered_arg = render_sequence(arg)
+    elif is_dataclass(arg):
+        rendered_arg = render_dataclass(arg)
     elif isinstance(arg, Mapping):
         rendered_arg = render_mapping(arg)
     elif isinstance(arg, date):
@@ -132,31 +134,110 @@ def render_timedelta(arg: timedelta) -> str:
     return f"#duration{render_mapping(obj)}"
 
 
-@dataclass
-class Dictionary:
+def render_dataclass(arg: Any) -> str:
     """
-    Helper class to render Python dataclasses by iterating over its fields
-    as if it were a dictionary.
+    Render a dataclass as either a mapping or a function call.
 
-    Inherit from `Dictionary` to inherit the render method
-    and use it with your dataclass.
+    The existence and value of an `__is_function__` member on the object
+    determines whether it is rendered as a function call. Setting it to return
+
+    Rendering of positional arguments in a Typst function call can be accomplished
+    by setting the `positional=True` flag on the dataclass field's metadata.
 
     You can specify that `None` values should be rendered instead
-    of being skipped with `keep_none=True` on the field's metadata.
+    of being skipped with `keep_none=True` on the dataclass field's metadata.
 
-    Example:
+    Examples:
         >>> from dataclasses import dataclass, field
         >>> @dataclass
-        ... class Foo(Dictionary):
+        ... class Foo:
         ...    bar: int | None = 4
         ...    qux: int | None = field(default=16, metadata={"keep_none": True})
         >>>
-        >>> Foo().render()
+        >>> render(Foo())
         '#(bar: 4, qux: 16)'
-        >>> Foo(bar=None).render()
+        >>> render(Foo(bar=None))
         '#(qux: 16)'
-        >>> Foo(qux=None).render()
+        >>> render(Foo(qux=None))
         '#(bar: 4, qux: none)'
+
+        >>> @dataclass
+        ... class FooFn:
+        ...    __is_function__ = True
+        ...    bar: int | None = field(metadata={"positional": True})
+        ...    qux: int | None = field(default=16, metadata={"keep_none": True})
+        >>>
+        >>> render(FooFn(4))
+        '#foo-fn(4, qux: 16)'
+        >>> render(FooFn(None))
+        '#foo-fn(qux: 16)'
+        >>> render(FooFn(4, qux=None))
+        '#foo-fn(4, qux: none)'
+    """
+
+    function = getattr(arg, "__is_function__", False)
+    fields = dataclass_fields_to_render(arg)
+
+    if function:
+        function = (
+            function
+            if isinstance(function, str)
+            else camel_to_kebab_case(arg.__class__.__name__)
+        )
+
+        arguments = ", ".join(
+            render_code(getattr(arg, field.name))
+            if field.metadata.get("positional", False)
+            else f"{field.name}: {render_code(getattr(arg, field.name))}"
+            for field in fields
+        )
+
+        rendered = f"#{function}({arguments})"
+    else:
+        mapping = render_mapping(
+            {field.name: getattr(arg, field.name) for field in fields}
+        )
+        rendered = f"#{mapping}"
+
+    return rendered
+
+
+def dataclass_fields_to_render(arg: Any) -> Iterable[Field]:
+    """
+    These dataclass fields should be rendered.
+    Defaults to skipping any fields with a value of `None`.
+    """
+
+    def check(field: Field) -> bool:
+        # When the value is `None`, check whether that should be kept.
+        if getattr(arg, field.name) is None:
+            return field.metadata.get("keep_none", False)
+
+        # Keep otherwise.
+        return True
+
+    return filter(check, fields(arg))
+
+
+def camel_to_kebab_case(arg: str) -> str:
+    """
+    Transform a CamelCase string to kebab-case.
+
+    Example:
+        >>> camel_to_kebab_case("ClassName")
+        'class-name'
+    """
+    return re.sub(
+        r"([a-z0-9])([A-Z])",
+        r"\1-\2",
+        arg,
+    ).lower()
+
+
+@dataclass
+class RenderDataclass:
+    """
+    Helper class that implements default dataclass rendering for mappings and functions.
     """
 
     def __str__(self) -> str:
@@ -164,90 +245,6 @@ class Dictionary:
 
     def render(self) -> str:
         """
-        Dataclass rendering to a Typst dictionary.
-
-        Modify `fields_to_render` to control which fields are included.
+        Render this dataclass as a string. See `render_dataclass` for more information.
         """
-        mapping = render_mapping(
-            {field.name: getattr(self, field.name) for field in self.fields_to_render()}
-        )
-        return f"#{mapping}"
-
-    def fields_to_render(self) -> Iterable[Field]:
-        """
-        These fields should be rendered. Defaults to skipping any fields with a value of `None`.
-        """
-
-        def check(field: Field) -> bool:
-            # When the value is `None`, check whether that should be kept.
-            if getattr(self, field.name) is None:
-                return field.metadata.get("keep_none", False)
-
-            # Keep otherwise.
-            return True
-
-        return filter(check, fields(self))
-
-
-@dataclass
-class Function(Dictionary):
-    """
-    Helper class to render Typst function calls from a Python dataclass.
-
-    Inherit from `Function` to inherit the render method.
-    The function name is derived from the class name
-    and is converted to kebab-case.
-
-    The dataclass' fields are used as the function arguments.
-
-    You can specify a positional argument in Typst by adding
-    `positional=True` on the field's metadata.
-
-    You can specify that `None` values should be rendered instead
-    of being skipped with `keep_none=True` on the field's metadata.
-
-    Example:
-        >>> from dataclasses import dataclass, field
-        >>> @dataclass
-        ... class FooFn(Function):
-        ...    bar: int | None = field(metadata={"positional": True})
-        ...    qux: int | None = field(default=16, metadata={"keep_none": True})
-        >>>
-        >>> FooFn(4).render()
-        '#foo-fn(4, qux: 16)'
-        >>> FooFn(None).render()
-        '#foo-fn(qux: 16)'
-        >>> FooFn(4, qux=None).render()
-        '#foo-fn(4, qux: none)'
-    """
-
-    def render(self) -> str:
-        """
-        Dataclass rendering to a Typst function call.
-
-        Modify `fields_to_render` to control which fields are included.
-        """
-
-        function = self.function()
-
-        options = ", ".join(
-            render_code(getattr(self, field.name))
-            if field.metadata.get("positional", False)
-            else f"{field.name}: {render_code(getattr(self, field.name))}"
-            for field in self.fields_to_render()
-        )
-
-        return f"#{function}({options})"
-
-    @classmethod
-    def function(cls) -> str:
-        """
-        Class method that returns the Typst function name that it represents.
-
-        Defaults to a kebab-case transformation of the ClassName.
-        """
-        return re.sub(
-            r"([a-z0-9])([A-Z])",
-            r"\1-\2",
-            cls.__name__,
-        ).lower()
+        return render_dataclass(self)

--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -234,10 +234,9 @@ def camel_to_kebab_case(arg: str) -> str:
     ).lower()
 
 
-@dataclass
-class RenderDataclass:
+class _RenderDataclass:
     """
-    Helper class that implements default dataclass rendering for mappings and functions.
+    Helper class that implements default dataclass rendering for dictionaries and functions.
     """
 
     def __str__(self) -> str:
@@ -248,3 +247,50 @@ class RenderDataclass:
         Render this dataclass as a string. See `render_dataclass` for more information.
         """
         return render_dataclass(self)
+
+
+class Dictionary(_RenderDataclass):
+    """
+    Helper class that implements default dataclass rendering for dictionaries in Typst.
+
+    Example:
+        >>> from dataclasses import dataclass, field
+        >>> @dataclass
+        ... class Foo(Dictionary):
+        ...    bar: int | None = 4
+        ...    qux: int | None = field(default=16, metadata={"keep_none": True})
+        >>>
+        >>> Foo().render()
+        '#(bar: 4, qux: 16)'
+        >>> Foo(bar=None).render()
+        '#(qux: 16)'
+        >>> Foo(qux=None).render()
+        '#(bar: 4, qux: none)'
+    """
+
+
+class Function(_RenderDataclass):
+    """
+    Helper class that implements default dataclass rendering for function calls in Typst.
+
+    By default, the class name is converted to kebab-case as the function name.
+    You can override this behavior by setting the `__is_function__` class variable
+    to a string of your choice.
+
+    Example:
+        >>> from dataclasses import dataclass, field
+        >>> @dataclass
+        ... class FooFn(Function):
+        ...    __is_function__ = True
+        ...    bar: int | None = field(metadata={"positional": True})
+        ...    qux: int | None = field(default=16, metadata={"keep_none": True})
+        >>>
+        >>> FooFn(4).render()
+        '#foo-fn(4, qux: 16)'
+        >>> FooFn(None).render()
+        '#foo-fn(qux: 16)'
+        >>> FooFn(4, qux=None).render()
+        '#foo-fn(4, qux: none)'
+    """
+
+    __is_function__: bool | str = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
 import itertools
+from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pandas as pd
 import pytest
+import typst
+import pypst.utils
 
 from pypst import Table
 
@@ -45,6 +49,25 @@ MULTI_FRAME = pd.DataFrame(
         ("B", "Y"): [10, 11, 12],
     }
 )
+
+
+@pytest.fixture
+def compile_text(tmp_path: Path):
+    path = tmp_path / "test.typ"
+
+    def _compile_text(text: str, *arg, **kwargs) -> bytes:
+        path.write_text(text, encoding="utf-8")
+        return typst.compile(path, *arg, **kwargs)
+
+    return _compile_text
+
+
+@pytest.fixture
+def compile_rendered(compile_text):
+    def _compile_rendered(arg: Any) -> bytes:
+        return compile_text(pypst.utils.render(arg))
+
+    return _compile_rendered
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def compile_text(tmp_path: Path):
 
 
 @pytest.fixture
-def compile_rendered(compile_text):
+def test_compile(compile_text):
     def _compile_rendered(arg: Any) -> bytes:
         return compile_text(pypst.utils.render(arg))
 

--- a/tests/test_figure.py
+++ b/tests/test_figure.py
@@ -7,53 +7,51 @@ from tests.conftest import DummyBody
 
 def test_dummy_figure(dummy_body):
     figure = Figure(DummyBody())
-    assert figure.render() == "#figure(\n  text(fill: red)[Hello, world!]\n)"
+    assert figure.render() == "#figure(text(fill: red)[Hello, world!])"
 
 
 def test_figure_with_placement(dummy_body):
     figure = Figure(dummy_body, placement="top")
-    rendered = figure.render().replace("\n  ", "\n")
-    assert rendered == "#figure(\ntext(fill: red)[Hello, world!],\nplacement: top\n)"
+    rendered = figure.render()
+    assert rendered == "#figure(text(fill: red)[Hello, world!], placement: top)"
 
 
 def test_figure_with_caption(dummy_body):
     figure = Figure(dummy_body, caption='"This is a caption"')
-    rendered = figure.render().replace("\n  ", "\n")
+    rendered = figure.render()
     assert rendered == (
-        '#figure(\ntext(fill: red)[Hello, world!],\ncaption: "This is a caption"\n)'
+        '#figure(text(fill: red)[Hello, world!], caption: "This is a caption")'
     )
 
 
 def test_figure_with_kind(dummy_body):
     figure = Figure(dummy_body, kind="table")
-    rendered = figure.render().replace("\n  ", "\n")
-    assert rendered == "#figure(\ntext(fill: red)[Hello, world!],\nkind: table\n)"
+    rendered = figure.render()
+    assert rendered == "#figure(text(fill: red)[Hello, world!], kind: table)"
 
 
 def test_figure_with_supplement(dummy_body):
     figure = Figure(dummy_body, supplement='"Table"')
-    rendered = figure.render().replace("\n  ", "\n")
-    assert rendered == (
-        '#figure(\ntext(fill: red)[Hello, world!],\nsupplement: "Table"\n)'
-    )
+    rendered = figure.render()
+    assert rendered == ('#figure(text(fill: red)[Hello, world!], supplement: "Table")')
 
 
 def test_figure_with_numbering(dummy_body):
     figure = Figure(dummy_body, numbering='"1"')
-    rendered = figure.render().replace("\n  ", "\n")
-    assert rendered == '#figure(\ntext(fill: red)[Hello, world!],\nnumbering: "1"\n)'
+    rendered = figure.render()
+    assert rendered == '#figure(text(fill: red)[Hello, world!], numbering: "1")'
 
 
 def test_figure_with_gap(dummy_body):
     figure = Figure(dummy_body, gap="10pt")
-    rendered = figure.render().replace("\n  ", "\n")
-    assert rendered == "#figure(\ntext(fill: red)[Hello, world!],\ngap: 10pt\n)"
+    rendered = figure.render()
+    assert rendered == "#figure(text(fill: red)[Hello, world!], gap: 10pt)"
 
 
 def test_figure_with_outlined(dummy_body):
     figure = Figure(dummy_body, outlined=True)
-    rendered = figure.render().replace("\n  ", "\n")
-    assert rendered == "#figure(\ntext(fill: red)[Hello, world!],\noutlined: true\n)"
+    rendered = figure.render()
+    assert rendered == "#figure(text(fill: red)[Hello, world!], outlined: true)"
 
 
 @pytest.mark.integration

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 from pypst import Image, utils
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 
 def test_flat_mapping():
@@ -38,3 +38,10 @@ def test_datetime():
         utils.render(obj)
         == "#datetime(year: 2024, month: 12, day: 18, hour: 15, minute: 34, second: 12)"
     )
+
+
+def test_timedelta():
+    obj = timedelta(
+        days=3, seconds=4, milliseconds=6
+    )  # millis are not supported in Typst
+    assert utils.render(obj) == "#duration(seconds: 4, days: 3)"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,9 @@
-import pytest
-from pypst import Image, utils
+from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
+
+import pytest
+
+from pypst import Image, utils
 
 
 def test_flat_mapping():
@@ -33,12 +36,24 @@ def test_date():
     assert utils.render(obj) == "#datetime(year: 2024, month: 12, day: 18)"
 
 
+@pytest.mark.integration
+def test_date_compile(test_compile):
+    obj = date(2024, 12, 18)
+    assert test_compile(obj)
+
+
 def test_datetime():
     obj = datetime(2024, 12, 18, 15, 34, 12)
     assert (
         utils.render(obj)
         == "#datetime(year: 2024, month: 12, day: 18, hour: 15, minute: 34, second: 12)"
     )
+
+
+@pytest.mark.integration
+def test_datetime_compile(test_compile):
+    obj = datetime(2024, 12, 18, 15, 34, 12)
+    test_compile(obj)
 
 
 def test_timedelta():
@@ -51,20 +66,56 @@ def test_timedelta():
 
 
 @pytest.mark.integration
-def test_date_compile(compile_rendered):
-    obj = date(2024, 12, 18)
-    assert compile_rendered(obj)
-
-
-@pytest.mark.integration
-def test_datetime_compile(compile_rendered):
-    obj = datetime(2024, 12, 18, 15, 34, 12)
-    compile_rendered(obj)
-
-
-@pytest.mark.integration
-def test_timedelta_compile(compile_rendered):
+def test_timedelta_compile(test_compile):
     obj = timedelta(
         days=3, seconds=4, microseconds=7e5
     )  # millis are not supported in Typst, but we round them to seconds.
-    compile_rendered(obj)
+    test_compile(obj)
+
+
+@dataclass
+class Foo(utils.RenderDataclass):
+    bar: int = 3
+    qux: float | None = 3.14
+
+    def render(self):
+        return f"#{super().render()}"
+
+
+def test_dataclass():
+    assert Foo().render() == "#(bar: 3, qux: 3.14)"
+    assert Foo(bar=5, qux=None).render() == "#(bar: 5, qux: none)"
+
+
+@pytest.mark.integration
+def test_dataclass_compile(test_compile):
+    obj = Foo()
+    test_compile(obj)
+
+
+@dataclass
+class FooFn(utils.Function):
+    bar: int = field(metadata={"positional": True})
+    qux: int = 16
+
+
+def test_function():
+    assert FooFn(4).render() == "#foo-fn(4, qux: 16)"
+
+
+@pytest.mark.integration
+def test_function_compile(test_compile):
+    @dataclass
+    class Rect(utils.Function):
+        body: str | None = field(default=None, metadata={"positional": True})
+        width: str = "10em"
+        height: str = "10%"
+        fill: str = "red"
+
+    obj = Rect()
+    assert obj.render() == "#rect(none, width: 10em, height: 10%, fill: red)"
+    test_compile(obj)
+
+    obj = Rect('"hello world"')
+    assert obj.render() == '#rect("hello world", width: 10em, height: 10%, fill: red)'
+    test_compile(obj)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 from pypst import Image, utils
+from datetime import date, datetime
 
 
 def test_flat_mapping():
@@ -24,3 +25,16 @@ def test_flat_sequence():
 def test_nested_seq():
     obj = ('"foo"', "bar", (2, Image("image.png")), None)
     assert utils.render(obj) == '("foo", bar, (2, image("image.png")), none)'
+
+
+def test_date():
+    obj = date(2024, 12, 18)
+    assert utils.render(obj) == "#datetime(year: 2024, month: 12, day: 18)"
+
+
+def test_datetime():
+    obj = datetime(2024, 12, 18, 15, 34, 12)
+    assert (
+        utils.render(obj)
+        == "#datetime(year: 2024, month: 12, day: 18, hour: 15, minute: 34, second: 12)"
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,20 +2,25 @@ from pypst import Image, utils
 
 
 def test_flat_mapping():
-    obj = dict(foo='"bar"', quux='"corge"', baz=Image("image.png"))
-    assert utils.render(obj) == '(foo: "bar", quux: "corge", baz: image("image.png"))'
+    obj = dict(foo='"bar"', quux='"corge"', qux=None, baz=Image("image.png"))
+    assert (
+        utils.render(obj)
+        == '(foo: "bar", quux: "corge", qux: none, baz: image("image.png"))'
+    )
 
 
 def test_nested_mapping():
-    obj = dict(foo=dict(bar='"quux"', baz=Image("image.png")))
-    assert utils.render(obj) == '(foo: (bar: "quux", baz: image("image.png")))'
+    obj = dict(foo=dict(bar='"quux"', qux=None, baz=Image("image.png")))
+    assert (
+        utils.render(obj) == '(foo: (bar: "quux", qux: none, baz: image("image.png")))'
+    )
 
 
 def test_flat_sequence():
-    obj = ('"foo"', "bar", 2, Image("image.png"))
-    assert utils.render(obj) == '("foo", bar, 2, image("image.png"))'
+    obj = ('"foo"', "bar", 2, Image("image.png"), None)
+    assert utils.render(obj) == '("foo", bar, 2, image("image.png"), none)'
 
 
 def test_nested_seq():
-    obj = ('"foo"', "bar", (2, Image("image.png")))
-    assert utils.render(obj) == '("foo", bar, (2, image("image.png")))'
+    obj = ('"foo"', "bar", (2, Image("image.png")), None)
+    assert utils.render(obj) == '("foo", bar, (2, image("image.png")), none)'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -74,17 +74,15 @@ def test_timedelta_compile(test_compile):
 
 
 @dataclass
-class Foo(utils.RenderDataclass):
+class Foo(utils.Dictionary):
     bar: int = 3
     qux: float | None = 3.14
-
-    def render(self):
-        return f"#{super().render()}"
 
 
 def test_dataclass():
     assert Foo().render() == "#(bar: 3, qux: 3.14)"
-    assert Foo(bar=5, qux=None).render() == "#(bar: 5, qux: none)"
+    assert Foo(bar=5, qux=None).render() == "#(bar: 5)"
+    assert Foo(bar=5, qux="none").render() == "#(bar: 5, qux: none)"
 
 
 @pytest.mark.integration
@@ -113,7 +111,7 @@ def test_function_compile(test_compile):
         fill: str = "red"
 
     obj = Rect()
-    assert obj.render() == "#rect(none, width: 10em, height: 10%, fill: red)"
+    assert obj.render() == "#rect(width: 10em, height: 10%, fill: red)"
     test_compile(obj)
 
     obj = Rect('"hello world"')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import pytest
 from pypst import Image, utils
 from datetime import date, datetime, timedelta
 
@@ -41,7 +42,29 @@ def test_datetime():
 
 
 def test_timedelta():
-    obj = timedelta(
-        days=3, seconds=4, milliseconds=6
-    )  # millis are not supported in Typst
+    obj = timedelta(days=3, seconds=4)
     assert utils.render(obj) == "#duration(seconds: 4, days: 3)"
+    obj = timedelta(
+        days=3, seconds=4, microseconds=7e5
+    )  # millis are not supported in Typst, but we round them to seconds.
+    assert utils.render(obj) == "#duration(seconds: 5, days: 3)"
+
+
+@pytest.mark.integration
+def test_date_compile(compile_rendered):
+    obj = date(2024, 12, 18)
+    assert compile_rendered(obj)
+
+
+@pytest.mark.integration
+def test_datetime_compile(compile_rendered):
+    obj = datetime(2024, 12, 18, 15, 34, 12)
+    compile_rendered(obj)
+
+
+@pytest.mark.integration
+def test_timedelta_compile(compile_rendered):
+    obj = timedelta(
+        days=3, seconds=4, microseconds=7e5
+    )  # millis are not supported in Typst, but we round them to seconds.
+    compile_rendered(obj)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,6 +81,7 @@ class Foo(utils.Dictionary):
 
 def test_dataclass():
     assert Foo().render() == "#(bar: 3, qux: 3.14)"
+    assert str(Foo()) == Foo().render()
     assert Foo(bar=5, qux=None).render() == "#(bar: 5)"
     assert Foo(bar=5, qux="none").render() == "#(bar: 5, qux: none)"
 
@@ -98,7 +99,9 @@ class FooFn(utils.Function):
 
 
 def test_function():
-    assert FooFn(4).render() == "#foo-fn(4, qux: 16)"
+    obj = FooFn(4)
+    assert obj.render() == "#foo-fn(4, qux: 16)"
+    assert obj.render() == str(obj)
 
 
 @pytest.mark.integration

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -74,7 +74,7 @@ def test_timedelta_compile(test_compile):
 
 
 @dataclass
-class Foo(utils.Dictionary):
+class Foo(utils.RenderDataclass):
     bar: int = 3
     qux: float | None = 3.14
 
@@ -93,7 +93,8 @@ def test_dataclass_compile(test_compile):
 
 
 @dataclass
-class FooFn(utils.Function):
+class FooFn(utils.RenderDataclass):
+    __is_function__ = True
     bar: int = field(metadata={"positional": True})
     qux: int = 16
 
@@ -107,7 +108,7 @@ def test_function():
 @pytest.mark.integration
 def test_function_compile(test_compile):
     @dataclass
-    class Rect(utils.Function):
+    class Rect(utils.RenderDataclass):
         body: str | None = field(default=None, metadata={"positional": True})
         width: str = "10em"
         height: str = "10%"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -74,7 +74,7 @@ def test_timedelta_compile(test_compile):
 
 
 @dataclass
-class Foo(utils.RenderDataclass):
+class Foo(utils.Dictionary):
     bar: int = 3
     qux: float | None = 3.14
 
@@ -93,7 +93,7 @@ def test_dataclass_compile(test_compile):
 
 
 @dataclass
-class FooFn(utils.RenderDataclass):
+class FooFn(utils.Function):
     __is_function__ = True
     bar: int = field(metadata={"positional": True})
     qux: int = 16
@@ -108,7 +108,7 @@ def test_function():
 @pytest.mark.integration
 def test_function_compile(test_compile):
     @dataclass
-    class Rect(utils.RenderDataclass):
+    class Rect(utils.Function):
         body: str | None = field(default=None, metadata={"positional": True})
         width: str = "10em"
         height: str = "10%"


### PR DESCRIPTION
This seems a good extension of the current `render_type`

Are there any other base types we might have missed? The current string treatment allows specifying `"none"` as well, but stringified nones (except when rendering) are a pain to work with in code that is generating documents.
