### PR TITLE
Fix handling of empty mappings

### DIFF
--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -96,7 +96,10 @@ def render_mapping(arg: Mapping[str, Any]) -> str:
     """
     Render a mapping from string to any object supported by `render`.
     """
-    return render_sequence(f"{k}: {render_code(v)}" for (k, v) in arg.items())
+    rendered = render_sequence(f"{k}: {render_code(v)}" for (k, v) in arg.items())
+    if rendered == "()":
+        return "(:)"
+    return rendered
 
 
 def render_sequence(arg: Iterable[Any]) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,11 @@ import pytest
 from pypst import Document, Image, utils
 
 
+def test_empty_mapping():
+    obj = dict()
+    assert utils.render(obj) == "(:)"
+
+
 def test_flat_mapping():
     obj = dict(foo='"bar"', quux='"corge"', qux=None, baz=Image("image.png"))
     assert (
@@ -81,6 +86,7 @@ class Foo(utils.Dictionary):
 
 def test_dataclass():
     assert Foo().render() == "#(bar: 3, qux: 3.14)"
+    assert Foo(bar=None, qux=None).render() == "#(:)"
     assert str(Foo()) == Foo().render()
     assert Foo(bar=5, qux=None).render() == "#(bar: 5)"
     assert Foo(bar=5, qux="none").render() == "#(bar: 5, qux: none)"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -99,6 +99,18 @@ def test_dataclass_compile(test_compile):
 
 
 @dataclass
+class EmptyFn(utils.Function):
+    nope: int | None = None
+
+
+def test_empty_fn():
+    assert (
+        EmptyFn().render() == "#empty-fn()"
+    ), "ensure that an empty function call is just () and not (:) like a mapping"
+    assert EmptyFn(2).render() == "#empty-fn(nope: 2)"
+
+
+@dataclass
 class FooFn(utils.Function):
     __is_function__ = True
     bar: int = field(metadata={"positional": True})


### PR DESCRIPTION
Empty mappings were rendered as `()` while in Typst these should be `(:)`.