### PR TITLE
feat: add further dataclass field configuration

### DIFF
--- a/pypst/utils.py
+++ b/pypst/utils.py
@@ -182,6 +182,12 @@ def render_dataclass(arg: Any) -> str:
     function = getattr(arg, "__is_function__", False)
     fields = dataclass_fields_to_render(arg)
 
+    def name(field: Field) -> str:
+        return field.metadata.get("name", field.name)
+
+    def value(field: Field) -> str:
+        return render_code(getattr(arg, field.name))
+
     if function:
         function = (
             function
@@ -189,17 +195,18 @@ def render_dataclass(arg: Any) -> str:
             else camel_to_kebab_case(arg.__class__.__name__)
         )
 
+        def is_positional(field: Field) -> bool:
+            return field.metadata.get("positional", False)
+
         arguments = ", ".join(
-            render_code(getattr(arg, field.name))
-            if field.metadata.get("positional", False)
-            else f"{field.name}: {render_code(getattr(arg, field.name))}"
+            value(field) if is_positional(field) else f"{name(field)}: {value(field)}"
             for field in fields
         )
 
         rendered = f"#{function}({arguments})"
     else:
         mapping = render_mapping(
-            {field.name: getattr(arg, field.name) for field in fields}
+            {name(field): getattr(arg, field.name) for field in fields}
         )
         rendered = f"#{mapping}"
 
@@ -213,6 +220,10 @@ def dataclass_fields_to_render(arg: Any) -> Iterable[Field]:
     """
 
     def check(field: Field) -> bool:
+        # Check whether the field should be skipped.
+        if field.metadata.get("skip", False):
+            return False
+
         # When the value is `None`, check whether that should be kept.
         if getattr(arg, field.name) is None:
             return field.metadata.get("keep_none", False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -115,11 +115,14 @@ class FooFn(utils.Function):
     __is_function__ = True
     bar: int = field(metadata={"positional": True})
     qux: int = 16
+    yes: int | None = field(default=None, metadata={"keep_none": True})
+    skip_me: int | None = field(default=None, metadata={"skip": True})
+    rename_me: int | None = field(default=1, metadata={"name": "one"})
 
 
 def test_function():
-    obj = FooFn(4)
-    assert obj.render() == "#foo-fn(4, qux: 16)"
+    obj = FooFn(4, skip_me=2)
+    assert obj.render() == "#foo-fn(4, qux: 16, yes: none, one: 1)"
     assert obj.render() == str(obj)
 
 


### PR DESCRIPTION
Hi there! 
I added some further field configuration options when rendering dataclasses. My typical use-case is the translation of `underscored_fields` in Python to `dashed-fields` in Typst and the skipping of variables that should not end up in the output for some more elaborate classes.
I thought of automating the conversion of underscores to dashes, but I think that might be a little intrusive. 